### PR TITLE
add afterAction, forceUpdate and skipCreate import options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,13 @@ export type CollectionExporterOptions = {
 	query?: Pick<Query, 'filter'|'sort'|'limit'>;
 	prefix?: string;
 	onExport?: (item: Item, srv: ItemsService) => Promise<Item | null>;
-	onImport?: (item: Item, srv: ItemsService) => Promise<Item | null>;
+	onImport?: (item: Item, srv: ItemsService, opts?: ItemImportOptions) => Promise<Item | null>;
+}
+
+export type ItemImportOptions = {
+	forceUpdate?: boolean;
+	skipCreate?: boolean;
+	afterAction?: () => Promise<null>;
 }
 
 //


### PR DESCRIPTION
Added afterAction, forceUpdate and skipCreate import options. Those can be used to empower users to properly import a Directus user and not only.