### PR TITLE
Allow for unattended installation of extension for CI and development

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ onImport: async (item, itemsSrv) => {
 | -------- | ----------- | ------- |
 | `SCHEMA_SYNC` | Set to automatically do **IMPORT**, **EXPORT** or **BOTH** | `null` |
 | `SCHEMA_SYNC_CONFIG` | (optional) An additional config file to use in addition, eg. `test_config.js` | `null` |
+| `SCHEMA_SYNC_AUTO_INSTALL` | (optional) Set to *true* to enable the automatic installation of schema sync for use in CI environments | `null` |
 
 
 ## CI Commands

--- a/src/copyConfig.ts
+++ b/src/copyConfig.ts
@@ -2,20 +2,24 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-export async function copyConfig(force: boolean, { logger }: { logger: any }) {
+export async function copyConfig(force: boolean, exitOnFail: boolean, { logger }: { logger: any }) {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const srcDir = path.resolve(__dirname, '../install');
   const targetDir = process.cwd();
+  let exit = false
 
   // Test if it doesn't already exist then if it does exit
   if (!force) {
     await fs.access(path.resolve(targetDir, 'schema-sync')).then(() => {
       logger.info('Config folder already exists, use --force to override');
-      process.exit(0);
+      if(exitOnFail)
+        process.exit(0);
+      exit = true;
     }).catch(() => {
       logger.info('Creating config folder...');
     });
   }
 
-  await fs.cp(srcDir, targetDir, { recursive: true });
+  if (!exit)
+    await fs.cp(srcDir, targetDir, { recursive: true });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,12 @@ const registerHook: HookConfig = async ({ action, init }, { env, services, datab
   if (env.SCHEMA_SYNC === 'BOTH' || env.SCHEMA_SYNC === 'IMPORT') {
     init('app.before', async () => {
       try {
+        if (env.SCHEMA_SYNC_AUTO_INSTALL == "true"){
+          await updateManager.ensureInstalled();
+          await copyConfig(false, false, { logger });
+          logger.info("Auto schema sync installation successful.");
+        }
+
         const meta = await ExportHelper.getExportMeta();
         if (!meta) return logger.info('Nothing exported yet it seems');
         if (!(await updateManager.lockForUpdates(meta.hash, meta.ts))) return; // Schema is locked / no change, nothing to do
@@ -147,7 +153,7 @@ const registerHook: HookConfig = async ({ action, init }, { env, services, datab
       .action(async ({ force }: { force: boolean }) => {
         logger.info('Installing Schema sync...');
         await updateManager.ensureInstalled();
-        await copyConfig(force, { logger });
+        await copyConfig(force, true, { logger });
 
         logger.info('Done!');
         process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,16 +81,16 @@ const registerHook: HookConfig = async ({ action, init }, { env, services, datab
     }
   }
 
+  const unattendedInstall = async () => {
+    await updateManager.ensureInstalled();
+    await copyConfig(false, false, { logger });
+    logger.info("Auto schema sync installation successful.");
+  }
+  
   // LOAD EXPORTED SCHEMAS & COLLECTIONS
   if (env.SCHEMA_SYNC === 'BOTH' || env.SCHEMA_SYNC === 'IMPORT') {
     init('app.before', async () => {
       try {
-        if (env.SCHEMA_SYNC_AUTO_INSTALL == "true"){
-          await updateManager.ensureInstalled();
-          await copyConfig(false, false, { logger });
-          logger.info("Auto schema sync installation successful.");
-        }
-
         const meta = await ExportHelper.getExportMeta();
         if (!meta) return logger.info('Nothing exported yet it seems');
         if (!(await updateManager.lockForUpdates(meta.hash, meta.ts))) return; // Schema is locked / no change, nothing to do
@@ -204,6 +204,9 @@ const registerHook: HookConfig = async ({ action, init }, { env, services, datab
           process.exit(1);
         }
       });
+
+      if (env.SCHEMA_SYNC_AUTO_INSTALL)
+        await unattendedInstall()
   });
 };
 


### PR DESCRIPTION
As of right now, anyone wanting to setup directus-schema-sync will have to install it using npx, then restart it to set the `SCHEMA_SYNC` environment variable to start syncing.

I propose that a `SCHEMA_SYNC_AUTO_INSTALL` environment variable be added to automatically install the extension.

I created an example [github repository](https://github.com/HDDTHR/schema-sync-dev-example) demonstrating how this could be used.