### PR TITLE
Added support for multiple enviroments

### DIFF
--- a/src/copyConfig.ts
+++ b/src/copyConfig.ts
@@ -1,16 +1,15 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { ExportHelper } from './utils';
 
 export async function copyConfig(force: boolean, { logger }: { logger: any }) {
 	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	const srcDir = path.resolve(__dirname, '../install');
-	const targetDir = process.cwd();
-
+	const srcDir = path.resolve(__dirname, '../install/schema-sync');
 	// Test if it doesn't already exist then if it does exit
 	if (!force) {
 		await fs
-			.access(path.resolve(targetDir, 'schema-sync'))
+			.access(ExportHelper.schemaDir)
 			.then(() => {
 				logger.info('Config folder already exists, use --force to override');
 				process.exit(0);
@@ -19,6 +18,5 @@ export async function copyConfig(force: boolean, { logger }: { logger: any }) {
 				logger.info('Creating config folder...');
 			});
 	}
-
-	await fs.cp(srcDir, targetDir, { recursive: true });
+	await fs.cp(srcDir, path.resolve(ExportHelper.schemaDir), { recursive: true });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { ADMIN_ACCOUNTABILITY, ExportHelper, nodeImport } from './utils';
 
 const registerHook: HookConfig = async ({ action, init }, { env, services, database, getSchema, logger }) => {
 	const { SchemaService, ItemsService } = services;
-
+	ExportHelper.environment = env.SCHEMA_SYNC_ENV
 	const schemaOptions = {
 		split: typeof env.SCHEMA_SYNC_SPLIT === 'boolean' ? env.SCHEMA_SYNC_SPLIT : true,
 	};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,8 +10,11 @@ export function nodeImport(dir: string, file: string) {
 }
 
 export class ExportHelper {
+
+	static environment = 'default';
+
 	static get schemaDir() {
-		return resolve(process.cwd(), 'schema-sync');
+		return resolve(process.cwd(), 'schema-sync',this.environment);
 	}
 
 	static get dataDir() {


### PR DESCRIPTION
Hello this is my first ever contribution to a project so let me know if i do anything wrong.

**What did i do ?**
I added support for multiple environments. Each environment will be placed in a sub folder of schema-sync.  With the `SCHEMA_SYNC_ENV` environment key it is possible to choose the environment. If the `SCHEMA_SYNC_ENV` is not set it will default the the `default` environment.

**Why ?**
In the project that i`m currently working on i need data that can be used to setup a new instance and i need separate data for testing. Both need a separate config.js and a separate  directus_config.js. And an export of our default environment should not overwrite the the testing data.

**Remarks**
This change would break existing installations as schema sync now expects the config files to be in the default sub folder of the schema_sync folder.