### PR TITLE
Reload directus modules if neccessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"release-channel": "node ./scripts/release-channel.js"
 	},
 	"devDependencies": {
-		"@directus/api": "^22.0.0",
 		"@directus/extensions": "^3.0.0",
 		"@directus/extensions-sdk": "^12.1.3",
 		"@directus/types": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"release-channel": "node ./scripts/release-channel.js"
 	},
 	"devDependencies": {
+		"@directus/api": "^22.0.0",
 		"@directus/extensions": "^3.0.0",
 		"@directus/extensions-sdk": "^12.1.3",
 		"@directus/types": "^13.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { HookConfig } from '@directus/extensions';
 import type { SchemaOverview } from '@directus/types';
+import { getFlowManager } from '@directus/api/flows';
 import { condenseAction } from './condenseAction';
 import { copyConfig } from './copyConfig';
 import { ExportManager } from './exportManager';
@@ -96,6 +97,11 @@ const registerHook: HookConfig = async ({ action, init }, { env, services, datab
 		}
 	}
 
+	async function reloadDirectusModules() {
+		const flowManager = getFlowManager();
+		await flowManager.reload();
+	}
+
 	// LOAD EXPORTED SCHEMAS & COLLECTIONS
 	if (env.SCHEMA_SYNC === 'BOTH' || env.SCHEMA_SYNC === 'IMPORT') {
 		init('app.before', async () => {
@@ -116,6 +122,7 @@ const registerHook: HookConfig = async ({ action, init }, { env, services, datab
 				await updateManager.releaseLock();
 			} finally {
 				await attachExporters();
+				await reloadDirectusModules();
 			}
 		});
 	} else {


### PR DESCRIPTION
Reload directus modules after data import. Currently only flows are reloaded.

**Reason**
Reload is neccessary, as directus builds a map of valid flow webhooks on startup and does not recognize new flow entries without a 'reload' event.